### PR TITLE
Revert assertThrows* 1.x methods signature

### DIFF
--- a/AssertThrows.php
+++ b/AssertThrows.php
@@ -35,9 +35,9 @@ trait AssertThrows
      * @param mixed ...$params
      * @throws Throwable
      */
-    public function assertThrows($throws, callable $func, array $params = [])
+    public function assertThrows($throws, callable $func, ...$params)
     {
-        $this->assertThrowsWithMessage($throws, null, $func, $params);
+        $this->assertThrowsWithMessage($throws, null, $func, ...$params);
     }
 
     /**
@@ -49,7 +49,7 @@ trait AssertThrows
      * @param mixed ...$params
      * @throws Throwable
      */
-    public function assertThrowsWithMessage($throws, ?string $message, callable $func, array $params = [])
+    public function assertThrowsWithMessage($throws, ?string $message, callable $func, ...$params)
     {
         if ($throws instanceof Throwable) {
             $message = $throws->getMessage();
@@ -61,7 +61,7 @@ trait AssertThrows
         }
 
         try {
-            if ($params !== []) {
+            if (!empty($params)) {
                 call_user_func_array($func, $params);
             } else {
                 call_user_func($func);
@@ -117,9 +117,9 @@ trait AssertThrows
      * @param callable $func
      * @param mixed ...$params
      */
-    public function assertDoesNotThrow($throws, callable $func, array $params = [])
+    public function assertDoesNotThrow($throws, callable $func, ...$params)
     {
-        $this->assertDoesNotThrowWithMessage($throws, null, $func, $params);
+        $this->assertDoesNotThrowWithMessage($throws, null, $func, ...$params);
     }
 
     /**
@@ -130,7 +130,7 @@ trait AssertThrows
      * @param callable $func
      * @param mixed ...$params
      */
-    public function assertDoesNotThrowWithMessage($throws, ?string $message, callable $func, array $params = [])
+    public function assertDoesNotThrowWithMessage($throws, ?string $message, callable $func, ...$params)
     {
         if ($throws instanceof Throwable) {
             $message = $throws->getMessage();
@@ -138,7 +138,7 @@ trait AssertThrows
         }
 
         try {
-            if ($params !== []) {
+            if (!empty($params)) {
                 call_user_func_array($func, $params);
             } else {
                 call_user_func($func);

--- a/tests/AssertThrowsTest.php
+++ b/tests/AssertThrowsTest.php
@@ -62,6 +62,20 @@ final class AssertThrowsTest extends TestCase
     public function testAssertThrowsWithParams()
     {
         $func = function (string $foo, string $bar): void {
+            throw new MyException($foo.$bar);
+        };
+
+        $this->assertThrows(
+            MyException::class,
+            $func,
+            'foo',
+            'bar'
+        );
+    }
+
+    public function testAssertThrowsWithMessageWithParams()
+    {
+        $func = function (string $foo, string $bar): void {
             throw new Exception($foo.$bar);
         };
 
@@ -69,7 +83,8 @@ final class AssertThrowsTest extends TestCase
             Exception::class,
             'foobar',
             $func,
-            ['foo', 'bar']
+            'foo',
+            'bar'
         );
     }
 
@@ -87,6 +102,17 @@ final class AssertThrowsTest extends TestCase
         $this->assertDoesNotThrow(new RuntimeException('foo'), $func);
         $this->assertDoesNotThrowWithMessage(Exception::class, 'bar', $func);
         $this->assertDoesNotThrow(new Exception('bar'), $func);
+    }
+
+    public function testAssertDoesNotThrowWithParams()
+    {
+        $func = function (string $foo, string $bar): void {
+            throw new Exception($foo.$bar);
+        };
+
+        $this->assertDoesNotThrowWithMessage(Exception::class, 'bar', $func, 'bar');
+        $this->assertDoesNotThrowWithMessage(Exception::class, 'foobar', $func, 'bar', 'foo');
+        $this->assertDoesNotThrow(RuntimeException::class, $func, 'bar', 'foo');
     }
 }
 


### PR DESCRIPTION
This PR reverts the change requiring all calls using assertThrows to be converted from a variable-length list of arguments to using an array.